### PR TITLE
🛂 Remove GM-only restriction from execution script fields

### DIFF
--- a/module/data/effects/eae.mjs
+++ b/module/data/effects/eae.mjs
@@ -30,7 +30,6 @@ export default class EarthdawnActiveEffectData extends ActiveEffectDataModel {
       } ),
       executionScript:  new fields.JavaScriptField( {
         required: false,
-        gmOnly:   true,
         initial:  "/**\n* This scope has the following variables available:\n* - effect: The \`EarthdawnActiveEffect\` document instance this script lives on\n* - parent: The parent document of this effect, either an \`ActorEd\` or an \`ItemEd\`\n*/\n\n",
       } ),
       transferToTarget: new fields.BooleanField( {

--- a/system.json
+++ b/system.json
@@ -200,10 +200,8 @@
   "documentTypes": {
     "ActiveEffect": {
       "eae": {
-        "gmOnlyFields": ["executionScript"]
       },
       "condition": {
-        "gmOnlyFields": ["executionScript"]
       }
     },
     "Actor": {


### PR DESCRIPTION
Otherwise players cant create effects :/ 
Not happy, we should look for some other solution to at least make sure it's safe to do that way...