### PR TITLE
🐛 Fix lp increase logic to use correct level

### DIFF
--- a/module/data/item/path.mjs
+++ b/module/data/item/path.mjs
@@ -228,7 +228,7 @@ export default class PathData extends ClassTemplate.mixin(
       return;
     }
   
-    return this.parent;
+    return updatedPath;
   }
 
   // endregion

--- a/module/data/item/questor.mjs
+++ b/module/data/item/questor.mjs
@@ -187,7 +187,7 @@ export default class QuestorData extends ClassTemplate.mixin(
 
     // possibly update the associated devotion
     const questorDevotion = await fromUuid( this.questorDevotion );
-    if ( !questorDevotion ) return this.parent;
+    if ( !questorDevotion ) return this.parentDocument;
 
     const content =  `
         <p>
@@ -205,7 +205,7 @@ export default class QuestorData extends ClassTemplate.mixin(
       await questorDevotion.update( { "system.level": nextLevel } )
     ) ) ui.notifications.warn( "ED.Notifications.Warn.questorItemNotUpdated" );
 
-    return this.parent;
+    return this.parentDocument;
   }
 
   // endregion

--- a/module/data/item/templates/class.mjs
+++ b/module/data/item/templates/class.mjs
@@ -161,7 +161,7 @@ export default class ClassTemplate extends ItemDataModel.mixin(
     if ( !proceed ) return;
 
     // update the class first
-    const updatedClass = await this.parent.update( { "system.level": nextLevel } );
+    const updatedClass = await this.parentDocument.update( { "system.level": nextLevel } );
     if ( updatedClass.system.level !== nextLevel ) {
       ui.notifications.warn( "ED.Notifications.Warn.classIncreaseProblems" );
     }
@@ -188,7 +188,7 @@ export default class ClassTemplate extends ItemDataModel.mixin(
     await this._increaseFreeAbilities( nextLevel );
 
     // we only land here if the class increase was successful
-    return this.parent;
+    return updatedClass;
   }
 
   async _increaseFreeAbilities( nextLevel ) {

--- a/module/data/item/templates/increasable-ability.mjs
+++ b/module/data/item/templates/increasable-ability.mjs
@@ -96,20 +96,7 @@ export default class IncreasableAbilityTemplate extends AbilityTemplate.mixin(
       || spendLp === "cancel"
       || spendLp === "close" ) return;
 
-    const currentLevel = this.unmodifiedLevel;
-
-    const updatedItem = await this.parent.update( {
-      "system.level": currentLevel + 1,
-    } );
-
-    if ( foundry.utils.isEmpty( updatedItem ) ) {
-      ui.notifications.warn(
-        game.i18n.localize( "ED.Notifications.Warn.abilityIncreaseProblems" )
-      );
-      return;
-    }
-
-    const updatedActor = await this.parent.actor.addLpTransaction(
+    await this.parent.actor.addLpTransaction(
       "spendings",
       LpSpendingTransactionData.dataFromLevelItem(
         this.parent,
@@ -118,12 +105,7 @@ export default class IncreasableAbilityTemplate extends AbilityTemplate.mixin(
       ),
     );
 
-    if ( foundry.utils.isEmpty( updatedActor ) )
-      ui.notifications.warn(
-        game.i18n.localize( "ED.Notifications.Warn.abilityIncreaseProblems" )
-      );
-
-    return this.parent;
+    return this.adjustLevel( 1 );
   }
 
   /** @inheritDoc */
@@ -144,7 +126,7 @@ export default class IncreasableAbilityTemplate extends AbilityTemplate.mixin(
    */
   async adjustLevel( amount ) {
     const currentLevel = this.unmodifiedLevel;
-    const updatedItem = await this.parent.update( {
+    const updatedItem = await this.parentDocument.update( {
       "system.level": currentLevel + amount,
     } );
 

--- a/module/data/item/thread.mjs
+++ b/module/data/item/thread.mjs
@@ -226,16 +226,6 @@ export default class ThreadData extends ItemDataModel.mixin(
     const newLevel = this.unmodifiedLevel + 1;
     const requiredLp = await this.getRequiredLpForLevel( newLevel );
 
-    const updatedThread = await this.parentDocument.update( {
-      "system.level": newLevel,
-    } );
-    if ( foundry.utils.isEmpty( updatedThread ) ) {
-      ui.notifications.warn(
-        game.i18n.localize( "ED.Notifications.Warn.abilityIncreaseProblems" )
-      );
-      return;
-    }
-
     const updatedActor = await actor.addLpTransaction(
       "spendings",
       LpSpendingTransactionData.dataFromLevelItem(
@@ -250,7 +240,17 @@ export default class ThreadData extends ItemDataModel.mixin(
         game.i18n.localize( "ED.Notifications.Warn.abilityIncreaseProblems" )
       );
 
-    return this.parentDocument;
+    const updatedThread = await this.parentDocument.update( {
+      "system.level": newLevel,
+    } );
+    if ( foundry.utils.isEmpty( updatedThread ) ) {
+      ui.notifications.warn(
+        game.i18n.localize( "ED.Notifications.Warn.abilityIncreaseProblems" )
+      );
+      return;
+    }
+
+    return updatedThread;
   }
 
   // endregion


### PR DESCRIPTION
See #3101

The update to the level was done before the lp transaction (update to the actor). Since the required lp are calculated dynamically, it took the new level instead of the old.