### PR TITLE
add additional checks for multi discipline

### DIFF
--- a/module/data/item/talent.mjs
+++ b/module/data/item/talent.mjs
@@ -167,8 +167,19 @@ export default class TalentData extends IncreasableAbilityTemplate.mixin(
     // each tier starts at the next value in the fibonacci sequence
     let tierModifier = LEGEND.lpIndexModForTier[sourceClass.system.order][this.tier];
 
-    if ( actor.isMultiDiscipline && this.unmodifiedLevel === 0 )
-      return LEGEND.multiDisciplineNewTalentLpCost[sourceClass.system.order][actor.minCircle];
+    // multi discipline talents of the first circle have an increased cost based on the lowest discipline other than the source discipline
+    if ( actor.isMultiDiscipline && this.unmodifiedLevel === 0 && this.source?.atLevel === 1 ) {
+      const disciplines = actor.classes.filter( classTypes => classTypes.type === SYSTEM_TYPES.Item.discipline );
+      const lowestOtherDiscipline = disciplines
+        .filter( d => d.id !== sourceClass.id )
+        .reduce( ( lowest, discipline ) => 
+          !lowest || discipline.system.level < lowest.system.level ? discipline : lowest
+        );
+
+      if ( !lowestOtherDiscipline ) return 0;
+      const costLevel = Math.min( lowestOtherDiscipline.system.level, 5 );
+      return LEGEND.multiDisciplineNewTalentLpCost[sourceClass.system.order][costLevel];
+    }
 
     return LEGEND.legendPointsCost[
       this.unmodifiedLevel

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -146,14 +146,6 @@ export default class ActorEd extends Actor {
   }
 
   /**
-   * The lowest circle of all disciplines this actor has.
-   * @type {number}
-   */
-  get minCircle() {
-    return Math.min( ...this.disciplines.map( discipline => discipline.system.level ) );
-  }
-
-  /**
    * Returns the namegiver item if this actor has one (has to be of type "character" or "npc" for this).
    * @type {Item|undefined}
    */


### PR DESCRIPTION
the newly learned discipline was allways caught by actor.minCircle

since minCircle was the only reference in the whole code I decided to remove it from the actor.mjs

I could not find a better way to not run into problems with several disciplines and ignoring the newest one.

resolves #3173