### PR TITLE
fix: attribute increase bug

### DIFF
--- a/module/data/actor/pc.mjs
+++ b/module/data/actor/pc.mjs
@@ -339,7 +339,7 @@ export default class PcData extends NamegiverTemplate {
       ],
       rejectClose: false
     } );
-
+    if ( !spendLp ) return;
     const attributeUpdate = await actor.update( {
       [`system.attributes.${attribute}.timesIncreased`]: currentIncrease + 1
     } );


### PR DESCRIPTION
Fixes #3161 
added a return if spendLP is null after cancelling the prompt, so Attributes are not increased