### PR TITLE
fix: Notes tab translations - 3464

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -254,7 +254,7 @@
         "talentsWithoutCategory":                 "Talents without category",
         "threads":                                "Threads",
         "truePattern":                            "TODO: Add translation",
-        "vocations":                              "Disciplines",
+        "vocations":                              "Vocations",
         "weapons":                                "Weapons",
         "weavingDifficulty":                      "Weaving Difficulty",
         "wovenThreads":                           "TODO: Add translation"


### PR DESCRIPTION
FIx for https://github.com/earthdawn-vtt/fvtt-earthdawn4e/issues/3464

Include translations for Notes tab of character actor sheet.

Fix #3464 