### PR TITLE
🐛 Fix thread items tab config cloning

### DIFF
--- a/module/applications/item/physical-item-sheet.mjs
+++ b/module/applications/item/physical-item-sheet.mjs
@@ -101,9 +101,7 @@ export default class PhysicalItemSheetEd extends ItemSheetEd {
     if ( group !== "truePattern" ) return originalTabsConfig;
 
     // create a tabConfig entry for each thread rank
-    const tabsConfig = {
-      ...this.constructor.TABS[ group ],
-    };
+    const tabsConfig = structuredClone( this.constructor.TABS[ group ] );
     const threadRanks = Object.values( this.document.system.truePattern?.threadItemLevels ?? {} );
     const threadRankTabs = threadRanks.map( levelData => {
       return {


### PR DESCRIPTION
Fix #3087

The static tabs configuration object was not properly cloned. Which means it got modified, and since its static, it applies to all item sheets.
Use `structuredClone` function to avoid shared object references between sheets.