### PR TITLE
fix: missing rolltype in knack ability sheet

### DIFF
--- a/templates/item/item-partials/item-details/details/item-details-knackAbility.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-knackAbility.hbs
@@ -7,4 +7,5 @@
     </fieldset>
 
     {{> "systems/ed4e/templates/item/item-partials/item-details/partials/targeting.hbs"}}
+    {{> "systems/ed4e/templates/item/item-partials/item-details/partials/roll-type.hbs"}}
 </div>


### PR DESCRIPTION
added the missing template part to knacks