### PR TITLE
🐛 Fix free abilities not automatically increasing with class level

### DIFF
--- a/module/data/item/templates/class.mjs
+++ b/module/data/item/templates/class.mjs
@@ -199,7 +199,7 @@ export default class ClassTemplate extends ItemDataModel.mixin(
     // increase all abilities of category "free" to new circle, if lower
     const freeAbilities = this.containingActor.items.filter(
       i => i.system.talentCategory === "free"
-        && i.system.source?.class === this.parent.uuid
+        && i.system.source?.class === this.parent.id
         && i.system.level < nextLevel
     );
     // TODO: check if there are any free abilities already on this level or higher


### PR DESCRIPTION
Fix #3304

Corrected reference to the sibling field `source.class`. Not a uuid anymore.