### PR TITLE
💥✨🗃️Make Equipment Items Executable Instead of Rollable

### DIFF
--- a/earthdawn4e.css
+++ b/earthdawn4e.css
@@ -804,6 +804,10 @@ h3.label--rail .label__text::after {
 .actor .icon--button.icon.icon--blood:focus-visible {
   color: var(--color-text-lt);
 }
+.actor .icon--button.icon.icon--target {
+  --icon-mask: url("/icons/svg/target.svg");
+  mask-mode: alpha;
+}
 .actor .ability-card__grid--container .icons__dice {
   --icon-cell: 25px;
   position: relative;

--- a/lang/de.json
+++ b/lang/de.json
@@ -1647,6 +1647,10 @@
             "consumable": {
               "hint":                             "Ist dieser Ausrüstungsgegenstand verbrauchbar?",
               "label":                            "Verbrauchbar"
+            },
+            "equipmentMacro": {
+              "hint":                             "Ein Macro das verwendet wird um Ausrüstung 'ausführen' zu können.",
+              "label":                            "Ausführungsmacro"
             }
           }
         },
@@ -2022,8 +2026,8 @@
               "label":                            "Schadensstufe"
             },
             "damageType": {
-              "hint":                             "TODO: Add translation",
-              "label":                            "TODO: Add translation"
+              "hint":                             "Art des Schadens der durch den Spruch verursacht wird",
+              "label":                            "Schadensart"
             },
             "element": {
               "subtype": {
@@ -3875,7 +3879,7 @@
       },
       "TruePattern": {
         "details":                                "Details",
-        "rank":                                   "TODO: Add translation",
+        "rank":                                   "Rang",
         "rankLevel":                              "Rang {level}"
       }
     },

--- a/lang/en.json
+++ b/lang/en.json
@@ -1647,6 +1647,10 @@
             "consumable": {
               "hint":                             "Is this equipment consumable?",
               "label":                            "Consumable"
+            },
+            "equipmentMacro": {
+              "hint":                             "A macro that can be used to make the equipment executable.",
+              "label":                            "Execution Macro"
             }
           }
         },

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1647,6 +1647,10 @@
             "consumable": {
               "hint":                             "Consommable",
               "label":                            "Consommable"
+            },
+            "equipmentMacro": {
+              "hint":                             "TODO: Add translation",
+              "label":                            "TODO: Add translation"
             }
           }
         },

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1647,6 +1647,10 @@
             "consumable": {
               "hint":                             "TODO: Add translation",
               "label":                            "TODO: Add translation"
+            },
+            "equipmentMacro": {
+              "hint":                             "TODO: Add translation",
+              "label":                            "TODO: Add translation"
             }
           }
         },

--- a/less/global/icons.less
+++ b/less/global/icons.less
@@ -122,6 +122,10 @@
         color: var(--color-text-lt);     
       }
     }
+    &.icon--target {
+      --icon-mask: url("/icons/svg/target.svg");
+      mask-mode: alpha;
+    }
   }
 
   /* ======================= Abilities ======================= */

--- a/module/applications/actor/sentient-sheet.mjs
+++ b/module/applications/actor/sentient-sheet.mjs
@@ -46,6 +46,7 @@ export default class ActorSheetEdSentient extends ActorSheetEd {
       },
       changeItemStatus: ActorSheetEdSentient.changeItemStatus,
       downgradeItem:    ActorSheetEdSentient._onAdjustItemLevel,
+      executable:       ActorSheetEdSentient.executable,
       initiative:       ActorSheetEdSentient.rollInitiative,
       jumpUp:           ActorSheetEdSentient.jumpUp,
       knockdown:        ActorSheetEdSentient.knockdownTest,
@@ -305,11 +306,18 @@ export default class ActorSheetEdSentient extends ActorSheetEd {
     const rollType = target.dataset.rollType;
     if ( rollType === "attribute" ) {
       this.document.rollAttributeBased( target.dataset.attribute, );
-    } else if ( rollType === "equipment" ) {
-      const li = target.closest( ".item-id" );
-      const equipment = this.document.items.get( li.dataset.itemId );
-      this.document.executeEquipmentMacro( equipment, { event: event } );
     }
+  }
+
+  /**
+   * For documents that have a macro to execute, execute it.
+   * @type {ApplicationClickAction}
+   */
+  static async executable( event, target ) {
+    event.preventDefault();
+    const li = target.closest( ".item-id" );
+    const document = this.document.items.get( li?.dataset?.itemId );
+    return document.system.executeMacro( { event: event } );
   }
 
   /**

--- a/module/applications/actor/sentient-sheet.mjs
+++ b/module/applications/actor/sentient-sheet.mjs
@@ -308,7 +308,7 @@ export default class ActorSheetEdSentient extends ActorSheetEd {
     } else if ( rollType === "equipment" ) {
       const li = target.closest( ".item-id" );
       const equipment = this.document.items.get( li.dataset.itemId );
-      this.document.rollEquipment( equipment, { event: event } );
+      this.document.executeEquipmentMacro( equipment, { event: event } );
     }
   }
 

--- a/module/data/abstract/system-data-model.mjs
+++ b/module/data/abstract/system-data-model.mjs
@@ -387,6 +387,31 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
     return `await foundry.applications.ui.Hotbar.toggleDocumentSheet("${this.parent.uuid}");`;
   }
 
+  /**
+   * Retrieves the default macro associated with the parent document or creates one if it does not exist.
+   * @param {object} [options] - Optional parameters for the `Macro.create` method.
+   * @returns {Promise<Macro|null>} A promise resolving to the default macro object if found,
+   *                                    or undefined if no macro is associated or created.
+   */
+  async getDefaultMacro( options = {} ) {
+    return game.macros.getName( this.parentDocument?.name )
+      ?? ( await this.parentDocument?.toMacro( options ) )
+      ?? null;
+  }
+
+  /**
+   * Executes the default macro command associated with this object.
+   * @param {object} [scope]    Optional additional context to pass to the macro execution.
+   *                            This will be merged with the default context. Contains
+   *                            the containing actor and parent document by default.
+   * @returns {Promise<*>}      A promise resolving to the result of the macro execution, see {@link Macro#execute}.
+   * @throws {Error}            If the macro document referenced by this item does not exist.
+   */
+  async executeMacro( scope = {} ) {
+    const macro = await this.getDefaultMacro();
+    return macro.execute( { actor: this.containingActor, item: this.parentDocument, ...scope } );
+  }
+
   // endregion
 
   // region Rolling

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -37,6 +37,10 @@ export default class EquipmentData extends PhysicalItemTemplate.mixin(
         initial:  0,
         integer:  true,
       } ),
+      macro: new fields.DocumentUUIDField( {
+        type:     "Macro",
+        embedded: false,
+      } )
     } );
   }
 

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -77,4 +77,22 @@ export default class EquipmentData extends PhysicalItemTemplate.mixin(
 
   // endregion
 
+  // region Methods
+
+  /**
+   * Execute the macro attached to an equipment Item, if available.
+   * @param {object} scope        Additional variables that should be passed to the macro scope.
+   * @returns {Promise<unknown>|void} A promise containing a created {@link foundry.documents.ChatMessage}
+   *                                  (or `undefined`) if a chat macro or the return value if a script macro.
+   *                                  A void return is possible if the user is not permitted to execute macros
+   *                                  or a script macro execution fails.
+   * @throws {Error}               If the macro document referenced by this item does not exist.
+   */
+  async executeEquipmentMacro( scope = {} ) {
+    const macro = /** @type {foundry.documents.Macro} */ await fromUuid( this.equipmentMacro );
+    return macro.execute( { actor: this.containingActor, item: this.parentDocument, ...scope } );
+  }
+
+  // endregion
+
 }

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -79,18 +79,10 @@ export default class EquipmentData extends PhysicalItemTemplate.mixin(
 
   // region Methods
 
-  /**
-   * Execute the macro attached to an equipment Item, if available.
-   * @param {object} scope        Additional variables that should be passed to the macro scope.
-   * @returns {Promise<unknown>|void} A promise containing a created {@link foundry.documents.ChatMessage}
-   *                                  (or `undefined`) if a chat macro or the return value if a script macro.
-   *                                  A void return is possible if the user is not permitted to execute macros
-   *                                  or a script macro execution fails.
-   * @throws {Error}               If the macro document referenced by this item does not exist.
-   */
-  async executeEquipmentMacro( scope = {} ) {
-    const macro = /** @type {foundry.documents.Macro} */ await fromUuid( this.equipmentMacro );
-    return macro.execute( { actor: this.containingActor, item: this.parentDocument, ...scope } );
+  /** @inheritDoc */
+  async getDefaultMacro( options = {} ) {
+    if ( !this.equipmentMacro ) return;
+    return fromUuid( this.equipmentMacro );
   }
 
   // endregion

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -37,7 +37,7 @@ export default class EquipmentData extends PhysicalItemTemplate.mixin(
         initial:  0,
         integer:  true,
       } ),
-      macro: new fields.DocumentUUIDField( {
+      equipmentMacro: new fields.DocumentUUIDField( {
         type:     "Macro",
         embedded: false,
       } )

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -1,9 +1,7 @@
-import TargetTemplate from "./targeting.mjs";
 import MatrixTemplate from "./matrix.mjs";
 import GrimoireTemplate from "./grimoire.mjs";
 import ItemDataModel from "../../abstract/item-data-model.mjs";
 import TruePatternData from "../../thread/true-pattern.mjs";
-import * as ACTIONS from "../../../config/actions.mjs";
 import * as ITEMS from "../../../config/items.mjs";
 
 
@@ -24,7 +22,6 @@ import * as ITEMS from "../../../config/items.mjs";
 export default class PhysicalItemTemplate extends ItemDataModel.mixin(
   GrimoireTemplate,
   MatrixTemplate,
-  TargetTemplate,
 ) {
 
   // region Static Properties
@@ -108,34 +105,6 @@ export default class PhysicalItemTemplate extends ItemDataModel.mixin(
         min:      0,
         initial:  0,
         integer:  true,
-      } ),
-      usableItem: new fields.SchemaField( {
-        isUsableItem: new fields.BooleanField( {
-          required: true,
-        } ),
-        arbitraryStep: new fields.NumberField( {
-          required: true,
-          nullable: false,
-          min:      0,
-          initial:  0,
-          integer:  true,
-        } ),
-        action: new fields.StringField( {
-          required: true,
-          nullable: true,
-          blank:    true,
-          choices:  ACTIONS.action,
-          initial:  "standard",
-        } ),
-        recoveryPropertyValue: new fields.NumberField( {
-          required: true,
-          nullable: false,
-          min:      0,
-          max:      5,
-          initial:  0,
-          choices:  ITEMS.recoveryProperty,
-          integer:  true,
-        } ),
       } ),
       itemStatus: new fields.StringField( {
         required: true,
@@ -266,16 +235,6 @@ export default class PhysicalItemTemplate extends ItemDataModel.mixin(
     return this.parent.update( {
       "system.itemStatus": "owned"
     } );
-  }
-
-  // endregion
-
-  // region Migration
-
-  /** @inheritDoc */
-  static migrateData( source ) {
-    return super.migrateData( source );
-    // specific migration functions
   }
 
   // endregion

--- a/module/data/item/templates/rollable.mjs
+++ b/module/data/item/templates/rollable.mjs
@@ -1,6 +1,5 @@
 import EdRollOptions from "../../roll/common.mjs";
 import SystemDataModel from "../../abstract/system-data-model.mjs";
-import { SYSTEM_TYPES } from "../../../constants/constants.mjs";
 import * as ACTIONS from "../../../config/actions.mjs";
 import * as ITEMS from "../../../config/items.mjs";
 import * as MAGIC from "../../../config/magic.mjs";
@@ -129,11 +128,7 @@ export default class RollableTemplate extends SystemDataModel {
 
   /** @inheritDoc */
   getDefaultMacroCommand( item, options = {} ) {
-    const physicalItemTypes = [ SYSTEM_TYPES.Item.armor, SYSTEM_TYPES.Item.equipment, SYSTEM_TYPES.Item.shield, SYSTEM_TYPES.Item.weapon, ];
-    if ( physicalItemTypes.includes( item.type ) ) {
-      // Physical items have to use actor.rollEquipment() instead of item.system.roll()
-      return `const item = await fromUuid("${this.parent.uuid}");\nawait item.actor.rollEquipment(item);`;
-    } else {
+    if ( item.system?.roll instanceof Function ) {
       return `const item = await fromUuid("${this.parent.uuid}");\nawait item.system.roll()`;
     }
   }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,6 +1,4 @@
 /* eslint-disable complexity */
-import EdRollOptions from "../data/roll/common.mjs";
-import RollPrompt from "../applications/global/roll-prompt.mjs";
 import DocumentCreateDialog from "../applications/global/document-creation.mjs";
 import LegendPointHistory from "../applications/advancement/lp-history.mjs";
 import LpEarningTransactionData from "../data/advancement/lp-earning-transaction.mjs";
@@ -1142,34 +1140,8 @@ export default class ActorEd extends Actor {
    * @returns {Promise<EdRoll>}   The processed Roll.
    */
   async rollEquipment( equipment, options = {} ) {
-    const arbitraryStep = equipment.system.usableItem.arbitraryStep;
-    const difficulty = equipment.system.getDifficulty();
-    if ( !difficulty ) {
-      throw new Error( "ED | ActorEd.rollEquipment | Ability is not part of Targeting Template, please call your Administrator!" );
-    }
-
-    const difficultyFinal = { base: difficulty };
-    const chatFlavor = _loc( "ED.Chat.Flavor.rollEquipment", {
-      sourceActor: this.name,
-      equipment:   equipment.name,
-      step:        arbitraryStep
-    } );
-
-    const arbitraryFinalStep = { base: arbitraryStep };
-    const edRollOptions = EdRollOptions.fromActor(
-      {
-        testType:         "action",
-        rollType:         "arbitrary",
-        strain:           0,
-        target:           difficultyFinal,
-        step:             arbitraryFinalStep,
-        devotionRequired: false,
-        chatFlavor:       chatFlavor
-      },
-      this
-    );
-    const roll = await RollPrompt.waitPrompt( edRollOptions, options );
-    return this.processRoll( roll, { rollToMessage: true } );
+    const macro = /** @type {Macro} */ await fromUuid( equipment.system.macro );
+    return macro.execute( {} );
   }
 
   /**

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1133,14 +1133,14 @@ export default class ActorEd extends Actor {
   }
 
   /**
-   * @summary                     Equipment rolls are a subset of Action test resembling non-attack actions like Talents, skills etc.
-   * @description                 Roll an Equipment item. use {@link RollPrompt} for further input data.
+   * Execute the macro attached to an equipment Item, if available.
    * @param {ItemEd} equipment    Equipment must be of type EquipmentTemplate & TargetingTemplate
    * @param {object} scope        Additional variables that should be passed to the macro scope.
    * @returns {Promise<unknown>|void} A promise containing a created {@link foundry.documents.ChatMessage}
-   *                                  (or `undefined`) if a chat  macro or the return value if a script macro.
+   *                                  (or `undefined`) if a chat macro or the return value if a script macro.
    *                                  A void return is possible if the user is not permitted to execute macros
    *                                  or a script macro execution fails.
+   * @throws {Error}               If the macro document referenced by this item does not exist.
    */
   async executeEquipmentMacro( equipment, scope = {} ) {
     const macro = /** @type {Macro} */ await fromUuid( equipment.system.equipmentMacro );

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1136,12 +1136,15 @@ export default class ActorEd extends Actor {
    * @summary                     Equipment rolls are a subset of Action test resembling non-attack actions like Talents, skills etc.
    * @description                 Roll an Equipment item. use {@link RollPrompt} for further input data.
    * @param {ItemEd} equipment    Equipment must be of type EquipmentTemplate & TargetingTemplate
-   * @param {object} options      Any additional options for the {@link EdRoll}.
-   * @returns {Promise<EdRoll>}   The processed Roll.
+   * @param {object} scope        Additional variables that should be passed to the macro scope.
+   * @returns {Promise<unknown>|void} A promise containing a created {@link foundry.documents.ChatMessage}
+   *                                  (or `undefined`) if a chat  macro or the return value if a script macro.
+   *                                  A void return is possible if the user is not permitted to execute macros
+   *                                  or a script macro execution fails.
    */
-  async rollEquipment( equipment, options = {} ) {
+  async executeEquipmentMacro( equipment, scope = {} ) {
     const macro = /** @type {Macro} */ await fromUuid( equipment.system.equipmentMacro );
-    return macro.execute( {} );
+    return macro.execute( { actor: this, item: equipment, ...scope } );
   }
 
   /**

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1140,7 +1140,7 @@ export default class ActorEd extends Actor {
    * @returns {Promise<EdRoll>}   The processed Roll.
    */
   async rollEquipment( equipment, options = {} ) {
-    const macro = /** @type {Macro} */ await fromUuid( equipment.system.macro );
+    const macro = /** @type {Macro} */ await fromUuid( equipment.system.equipmentMacro );
     return macro.execute( {} );
   }
 

--- a/templates/actor/cards/equipment-card.hbs
+++ b/templates/actor/cards/equipment-card.hbs
@@ -1,6 +1,6 @@
-<div class="card__equipment {{#if (eq this.system.usableItem.isUsableItem true)}}favoritable{{/if}}" data-uuid="{{uuid}}">
-    <div class="equipment-card__grid--container" data-item-id="{{_id}}">
-        {{#if (eq this.system.usableItem.isUsableItem true)}}
+<div class="card__equipment {{#if this.system.macro}}favoritable{{/if}}" data-uuid="{{uuid}}">
+    <div class="equipment-card__grid--container item-id" data-item-id="{{_id}}">
+        {{#if this.system.macro}}
         <div class="equipment-card__grid--item icons__dice">
             <img class="equipment-icon" src="{{img}}" alt="{{name}}">
             <button

--- a/templates/actor/cards/equipment-card.hbs
+++ b/templates/actor/cards/equipment-card.hbs
@@ -1,6 +1,6 @@
-<div class="card__equipment {{#if this.system.macro}}favoritable{{/if}}" data-uuid="{{uuid}}">
+<div class="card__equipment {{#if this.system.equipmentMacro}}favoritable{{/if}}" data-uuid="{{uuid}}">
     <div class="equipment-card__grid--container item-id" data-item-id="{{_id}}">
-        {{#if this.system.macro}}
+        {{#if this.system.equipmentMacro}}
         <div class="equipment-card__grid--item icons__dice">
             <img class="equipment-icon" src="{{img}}" alt="{{name}}">
             <button

--- a/templates/actor/cards/equipment-card.hbs
+++ b/templates/actor/cards/equipment-card.hbs
@@ -6,8 +6,7 @@
             <button
                 type="button"
                 class="icon--button icon icon--d20 rollable icon--overlay"
-                data-action="rollable"
-                data-roll-type="equipment"
+                data-action="executable"
                 aria-label="{{localize 'ED.Roll.Equipment'}}">
             </button>
         </div>

--- a/templates/actor/cards/equipment-card.hbs
+++ b/templates/actor/cards/equipment-card.hbs
@@ -5,7 +5,7 @@
             <img class="equipment-icon" src="{{img}}" alt="{{name}}">
             <button
                 type="button"
-                class="icon--button icon icon--d20 rollable icon--overlay"
+                class="icon--button icon icon--target icon--overlay"
                 data-action="executable"
                 aria-label="{{localize 'ED.Roll.Equipment'}}">
             </button>

--- a/templates/item/item-partials/item-details/details/item-details-equipment.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-equipment.hbs
@@ -1,20 +1,18 @@
 <div id="base-details-equipment-item" class="item-details__equipment" data-editable="{{#if @root.editable}}editable{{else}}readonly{{/if}}">
-    
-    <fieldset>
-        <legend></legend>
-        {{formField systemFields.equipmentType name="system.equipmentType" value=item.system.equipmentType localize=true}}    {{formField systemFields.consumable name="system.consumable" value=item.system.consumable localize=true}}
-        {{#if (eq item.system.consumable true)}}
-            {{!-- ammunition --}}
-            {{formField systemFields.ammunition.fields.type name="system.ammunition.type" value=item.system.ammunition.type localize=true}}
-            {{!-- bundleSize --}}
-            {{formField systemFields.bundleSize name="system.bundleSize" value=item.system.bundleSize localize=true}}
-        {{/if}}
-    </fieldset>
 
-    {{!-- usable Item ?--}}
-    {{> "systems/ed4e/templates/item/item-partials/item-details/partials/usable-items.hbs"}}
-    {{#if (eq item.system.usableItem.isUsableItem true)}}
-        {{> "systems/ed4e/templates/item/item-partials/item-details/partials/targeting.hbs"}}
+  <fieldset>
+    <legend></legend>
+    {{formField systemFields.equipmentType name="system.equipmentType" value=item.system.equipmentType localize=true}}
+    {{formField systemFields.consumable name="system.consumable" value=item.system.consumable localize=true}}
+    {{#if (eq item.system.consumable true)}}
+    {{!-- ammunition --}}
+      {{formField systemFields.ammunition.fields.type name="system.ammunition.type" value=item.system.ammunition.type localize=true}}
+      {{!-- bundleSize --}}
+      {{formField systemFields.bundleSize name="system.bundleSize" value=item.system.bundleSize localize=true}}
     {{/if}}
-    {{> "systems/ed4e/templates/item/item-partials/item-details/details/item-details-physicalItems.hbs"}}
+  </fieldset>
+
+  {{!-- usable Item ?--}}
+  {{> "systems/ed4e/templates/item/item-partials/item-details/partials/usable-items.hbs"}}
+  {{> "systems/ed4e/templates/item/item-partials/item-details/details/item-details-physicalItems.hbs"}}
 </div>

--- a/templates/item/item-partials/item-details/partials/usable-items.hbs
+++ b/templates/item/item-partials/item-details/partials/usable-items.hbs
@@ -2,5 +2,5 @@
     <legend></legend>
 
     {{!-- Usable Item --}}
-    {{formField systemFields.macro value=item.system.macro localize=true}}
+    {{formField systemFields.macro value=item.system.equipmentMacro localize=true}}
 </fieldset>

--- a/templates/item/item-partials/item-details/partials/usable-items.hbs
+++ b/templates/item/item-partials/item-details/partials/usable-items.hbs
@@ -2,5 +2,5 @@
     <legend></legend>
 
     {{!-- Usable Item --}}
-    {{formField systemFields.macro value=item.system.equipmentMacro localize=true}}
+    {{formField systemFields.equipmentMacro value=item.system.equipmentMacro localize=true}}
 </fieldset>

--- a/templates/item/item-partials/item-details/partials/usable-items.hbs
+++ b/templates/item/item-partials/item-details/partials/usable-items.hbs
@@ -2,20 +2,5 @@
     <legend></legend>
 
     {{!-- Usable Item --}}
-    {{formField systemFields.usableItem.fields.isUsableItem name="system.usableItem.isUsableItem" value=item.system.usableItem.isUsableItem localize=true}}
+    {{formField systemFields.macro value=item.system.macro localize=true}}
 </fieldset>
-{{#if (eq item.system.usableItem.isUsableItem true)}}
-    <fieldset>
-        <legend></legend>
-
-            {{!-- Arbitrary Step --}}
-            {{formField systemFields.usableItem.fields.arbitraryStep name="system.usableItem.arbitraryStep" value=item.system.usableItem.arbitraryStep localize=true}}
-            
-            {{!-- Action --}}
-            {{formField systemFields.usableItem.fields.action name="system.usableItem.action" value=item.system.usableItem.action localize=true}}
-           
-            {{!-- Recovery Test Reference Value --}}
-            {{formField systemFields.usableItem.fields.recoveryPropertyValue name="system.usableItem.recoveryPropertyValue" type="number" value=item.system.usableItem.recoveryPropertyValue localize=true}}
-        
-    </fieldset>
-{{/if}}


### PR DESCRIPTION
# Breaking changes: test with new world

Resolves #1626 
Data Model changes that probably can't be reverted, so careful when testing.
Macros can now be attached to equipment and executed from equipment cards in actor sheets.

### Added
- `macro` field introduced for equipment items.
- `getDefaultMacro` and `executeMacro` methods added to the system data model.
- `executeEquipmentMacro` method for equipment items on actor
- Added `icon--target` styling for equipment actions.

### Changed
- `rollable` equipment to `executable`.
- Update sheets

### Removed
- remov `TargetTemplate` and `usableItem` fields from Equipment data model, consolidating into the `equipmentMacro` field.

### Fixed
- Added missing equipment item ID assignment.