### PR TITLE
💄 Make Roll Prompt Step Modifiers Collapsible

### DIFF
--- a/templates/prompts/roll/part-step.hbs
+++ b/templates/prompts/roll/part-step.hbs
@@ -13,14 +13,16 @@
     disabled=true
   }}
   {{#if ( ne testType "arbitrary") }}
-    <label class="modifier-description">{{localize "ED.Dialogs.RollPrompt.modifier"}}</label>
-    {{#each step.modifiers as |modifier|}}
-      {{formGroup
-        ../optionsFields.step.fields.modifiers.element
-        name=(concat "step.modifiers." @key)
-        value=modifier
-        label=@key
-      }}
-    {{/each}}
+    <details>
+      <summary class="modifier-description">{{localize "ED.Dialogs.RollPrompt.modifier"}}</summary>
+      {{#each step.modifiers as |modifier|}}
+        {{formGroup
+          ../optionsFields.step.fields.modifiers.element
+          name=(concat "step.modifiers." @key)
+          value=modifier
+          label=@key
+        }}
+      {{/each}}
+    </details>
   {{/if}}
 </fieldset>


### PR DESCRIPTION
Improve information overload by making step modifiers collapsible.

This is just a suggestion because I heard some feedback that a more simple prompt would help.
The big overhaul and nice-making of the roll prompt of course is still waiting.