### PR TITLE
🐛 Base Foundry Roll as default for Roll Tables

### DIFF
--- a/module/documents/_module.mjs
+++ b/module/documents/_module.mjs
@@ -8,5 +8,6 @@ export {default as CombatantEd} from "./combatant.mjs";
 export {default as EarthdawnActiveEffect} from "./active-effect.mjs";
 export {default as ItemEd} from "./item.mjs";
 export {default as JournalEntryEd} from "./journal.mjs";
+export {default as RollTableEd} from "./roll-table.mjs";
 
 export * as collections from "./collections/_module.mjs";

--- a/module/documents/roll-table.mjs
+++ b/module/documents/roll-table.mjs
@@ -1,0 +1,9 @@
+export default class RollTableEd extends foundry.documents.RollTable {
+
+  /** @inheritdoc */
+  roll( options = {} ) {
+    if ( !( options.roll instanceof Roll ) ) options.roll = new foundry.dice.Roll( this.formula );
+    return super.roll( options );
+  }
+
+}


### PR DESCRIPTION
Fix #3947