### PR TITLE
🐛 Fix Combat Turn Hooks and Effect Execution

### DIFF
--- a/module/data/effect/eae.mjs
+++ b/module/data/effect/eae.mjs
@@ -49,7 +49,7 @@ export default class EarthdawnActiveEffectData extends ActiveEffectDataModel {
         "effect",
         "parent",
         "options",
-        `{${ this.executionScript }\n}`,
+        `{${ this.execution.script }\n}`,
       );
       await fn.call( globalThis, this.parentDocument, this.parentDocument.parent, options );
     } catch ( error ) {

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -92,11 +92,15 @@ export default class CombatEd extends foundry.documents.Combat {
    * @param {boolean} options.force   Force the reset even if the Combatant#system.keepInitiative is `true`.
    */
   async resetInitiatives( options = { force: false } ) {
-    for ( const combatant of this.combatants ) {
-      if ( options.force || !combatant.system.keepInitiative ) {
-        await combatant.resetInitiative();
-      }
-    }
+    const updates = this.combatants
+      .filter( combatant => options.force || !combatant.system.keepInitiative )
+      .filter( combatant => combatant.initiative !== null )
+      .map( combatant => ( { _id: combatant.id, initiative: null, } ) );
+
+    if ( updates.length ) await this.updateEmbeddedDocuments( "Combatant", updates, {
+      combatTurn: this.turn,
+      turnEvents: false,
+    } );
   }
 
   /**

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -103,7 +103,7 @@ export default class CombatEd extends foundry.documents.Combat {
     if ( !combatant ) return;
     const effects = combatant.effects.filter(
       effect => effect.system?.execution.executable === true
-        && effect.system?.executeOn === executionTime
+        && effect.system?.execution.executeOn === executionTime
     );
 
     for ( const effect of effects ) {

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -9,6 +9,8 @@ import StartRoundCombatantPrompt from "../applications/combat/start-round-combat
  */
 export default class CombatEd extends foundry.documents.Combat {
 
+  // region Overrides
+
   /** @inheritdoc */
   _sortCombatants( a, b ) {
     // player characters always go first on a tie with NPCs
@@ -25,6 +27,8 @@ export default class CombatEd extends foundry.documents.Combat {
 
     return super.nextRound();
   }
+
+  // endregion
 
   // region Lifecycle Events
 
@@ -67,7 +71,7 @@ export default class CombatEd extends foundry.documents.Combat {
   /** @inheritdoc */
   async _onStartTurn( combatant, context ) {
     super._onStartTurn( combatant, context );
-    await this.#executeEffectsForAll( "turnStart" );
+    await this.#executeEffects( "turnStart", combatant.actor );
     if ( combatant.actor.statuses.has( "attuningOnTheFly" ) ) await combatant.actor.reattuneSpells();
   }
 
@@ -75,10 +79,12 @@ export default class CombatEd extends foundry.documents.Combat {
   async _onEndTurn( combatant, context ) {
     // add expire measured templates
     super._onEndTurn( combatant, context );
-    await this.#executeEffectsForAll( "turnEnd" );
+    await this.#executeEffects( "turnEnd", combatant.actor );
   }
 
   // endregion
+
+  // region Initiative
 
   /**
    * Reset the initiative of all combatants in this combat.
@@ -92,6 +98,28 @@ export default class CombatEd extends foundry.documents.Combat {
       }
     }
   }
+
+  /**
+   * Prompt all combatants to roll initiative.
+   * @returns {Promise<Awaited<unknown>[]>} The results of the prompts.
+   */
+  async #promptAllInitiatives() {
+    return Promise.all( this.combatants.map( combatant => {
+      if ( combatant.system.savePromptSettings ) return undefined;
+      const decidingUser = game.users.getDesignatedUser( user =>
+        combatant.isUsersPC( user )
+      );
+      if ( !decidingUser || !decidingUser.active ) return StartRoundCombatantPrompt.waitPrompt( {}, combatant );
+      else return decidingUser.query(
+        "ed4e.startCombatRoundPrompt",
+        { combatantUuid: combatant.uuid }
+      );
+    } ) );
+  }
+
+  // endregion
+
+  // region Effects
 
   /**
    * Execute ActiveEffects that are triggered by the given execution time.
@@ -124,22 +152,6 @@ export default class CombatEd extends foundry.documents.Combat {
     }
   }
 
-  /**
-   * Prompt all combatants to roll initiative.
-   * @returns {Promise<Awaited<unknown>[]>} The results of the prompts.
-   */
-  async #promptAllInitiatives() {
-    return Promise.all( this.combatants.map( combatant => {
-      if ( combatant.system.savePromptSettings ) return undefined;
-      const decidingUser = game.users.getDesignatedUser( user =>
-        combatant.isUsersPC( user )
-      );
-      if ( !decidingUser || !decidingUser.active ) return StartRoundCombatantPrompt.waitPrompt( {}, combatant );
-      else return decidingUser.query(
-        "ed4e.startCombatRoundPrompt",
-        { combatantUuid: combatant.uuid }
-      );
-    } ) );
-  }
+  // endregion
 
 }


### PR DESCRIPTION
Fixes #3911

- Correctly reset initiative at the start of a new round by batching updates. Otherwise Foundry rebuilds the turn order each time, therefore, can see combatant at start of turn if others not rolled yet.
- Ensure effects triggered during turns apply only to the current combatant.
- Fix incorrect property paths and references in effect execution data after data model changes in V14.